### PR TITLE
feature: allow different names

### DIFF
--- a/lib/formular/client/supervisor.ex
+++ b/lib/formular/client/supervisor.ex
@@ -6,7 +6,7 @@ defmodule Formular.Client.Supervisor do
   use Supervisor
 
   def start_link(config) do
-    Supervisor.start_link(__MODULE__, config, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, config)
   end
 
   @impl true


### PR DESCRIPTION
Stop using a global name in order to have multiple instances of formula clients running.