### PR TITLE
Chore/timeout on mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,25 @@
         Supervisor.start_link(children, opts)
       end
 
-      defp formular_client_config do
-        client_name: "myapp",
-        url: "wss://example.com/socket/websocket",
-        formulas: [
-          # format 1: binary key
-          "my-formula-1",
-          # format 2: {module to compile, key}
-          {MyMod2, "my-formula-2"},
-          # format 3: {module, key, context_module}
-          {MyMod3, "my-formula-3", MyHelperModule}
-        ]
-      end
+      defp formular_client_config,
+        do: Application.get_env(:my_app, :formular_client)
     end
+    ```
+
+    ```elixir
+    # file: config/config.exs
+
+    config :my_app, :formular_client,
+      client_name: "myapp",
+      url: "wss://example.com/socket/websocket",
+      formulas: [
+        # format 1: binary key
+        "my-formula-1",
+        # format 2: {module to compile, key}
+        {MyMod2, "my-formula-2"},
+        # format 3: {module, key, context_module}
+        {MyMod3, "my-formula-3", MyHelperModule}
+      ]
     ```
 
     where `url` points to a formular server.
@@ -56,12 +62,14 @@
 You can use `Formular.Client.Adapter.Mock` for testing.
 
 ```elixir
-config :formular_client, :adapter, {
-  Formular.Client.Adapter.Mock,
-  formulars: [
-    {"my-formula-1", fn _binding, _opts -> :foo end}
-  ]
-}
+# file: config/test.exs
+config :my_app, :formular_client,
+  :adapter: {
+    Formular.Client.Adapter.Mock,
+    formulars: [
+      {"my-formula-1", fn _binding, _opts -> :foo end}
+    ]
+  }
 ```
 
 Optionally, to change the return value for a formula dynamically, you can call `Formular.Client.Adapter.Mock.mock_global/2` as the following:

--- a/lib/formular/client/adapter/mock.ex
+++ b/lib/formular/client/adapter/mock.ex
@@ -1,8 +1,23 @@
+defmodule Formular.Client.MockError do
+  defexception [:message]
+
+  @impl true
+  def exception({:missing, _missing_formulas}) do
+    %Formular.Client.MockError{message: "Not all the formulas were mocked"}
+  end
+end
+
 defmodule Formular.Client.Adapter.Mock do
   alias Formular.Client.Cache
 
-  def start_link(_config, opts) do
+  require Logger
+
+  def start_link(config, opts) do
+    Logger.debug(["Starting mock formular intepreter."])
+
     {:ok, pid} = Agent.start_link(fn -> :ok end)
+
+    ensure_all_formulas_provided!(config.formulas, opts[:formulas])
 
     case opts[:formulas] do
       formulas when is_list(formulas) ->
@@ -15,6 +30,36 @@ defmodule Formular.Client.Adapter.Mock do
     end
 
     {:ok, pid}
+  end
+
+  defp ensure_all_formulas_provided!(required, provided) do
+    case ensure_all_formulas_provided(required, provided) do
+      :ok ->
+        :ok
+
+      {:missing, missing} ->
+        msg = """
+        Not all the formulas were mocked, missing:
+        #{inspect(missing)}.
+        """
+
+        Logger.error(msg)
+        # raise Formular.Client.MockError, {:missing, missing}
+        :ok
+    end
+  end
+
+  defp ensure_all_formulas_provided(required, provided) do
+    required = required |> Enum.map(&elem(&1, 1))
+    provided = provided |> Enum.map(&elem(&1, 0))
+
+    case required -- provided do
+      [] ->
+        :ok
+
+      missing ->
+        {:missing, missing}
+    end
   end
 
   def mock_global(name, function)

--- a/lib/formular/client/adapter/mock.ex
+++ b/lib/formular/client/adapter/mock.ex
@@ -44,8 +44,7 @@ defmodule Formular.Client.Adapter.Mock do
         """
 
         Logger.error(msg)
-        # raise Formular.Client.MockError, {:missing, missing}
-        :ok
+        raise Formular.Client.MockError, {:missing, missing}
     end
   end
 

--- a/lib/formular/client/config.ex
+++ b/lib/formular/client/config.ex
@@ -21,6 +21,7 @@ defmodule Formular.Client.Config do
     :client_name,
     :url,
     :formulas,
+    read_timeout: :infinity,
     compiler: {Formular.Client.Compiler, :compile, []},
     adapter: {Formular.Client.Adapter.Websocket, []}
   ]

--- a/lib/formular/client/listener.ex
+++ b/lib/formular/client/listener.ex
@@ -9,13 +9,24 @@ defmodule Formular.Client.Listener do
   end
 
   def start_link(config) do
-    GenServer.start_link(__MODULE__, Config.new(config))
+    config |> Config.new() |> start_link()
   end
 
   @impl true
   def init(config) do
+    Logger.info("Starting Formular Client.")
+
     {:ok, _child} = start_adapter(config)
-    wait_for_formulas(config)
+
+    # Attention here: we're blocking the starting process
+    # because we want to make sure other parts of the 
+    # application can only be started AFTER all the formulas
+    # has been loaded.
+    wait_for_formulas(
+      _now = :erlang.monotonic_time(),
+      config
+    )
+
     {:ok, config}
   end
 
@@ -42,17 +53,29 @@ defmodule Formular.Client.Listener do
     end
   end
 
-  defp wait_for_formulas(%{formulas: formulas} = config) do
-    all_loaded =
-      Enum.all?(formulas, fn {_, name, _} ->
-        Formular.Client.Cache.get(name)
-      end)
+  defp wait_for_formulas(start_at, %{formulas: formulas} = config) do
+    missing =
+      formulas
+      |> Stream.map(fn {_, name, _} -> name end)
+      |> Enum.reject(&Formular.Client.Cache.get(&1))
 
-    if all_loaded do
-      :ok
-    else
-      :timer.sleep(200)
-      wait_for_formulas(config)
+    case missing do
+      [] ->
+        :ok
+
+      _ ->
+        case config.read_timeout do
+          :infinity ->
+            :ok
+
+          n when is_integer(n) ->
+            if div(:erlang.monotonic_time() - start_at, 1_000_000) > n do
+              raise "timeout reading formulas"
+            end
+
+            :timer.sleep(200)
+            wait_for_formulas(start_at, config)
+        end
     end
   end
 end


### PR DESCRIPTION
Fix #3 

In this PR:

* [x] enable the user to specify a timeout setting for getting the formulas from the server
* [x] when the mocking adapter is used and not all the formulas are mocked, there would be an error raised to prevent infinity waiting, which is confusing.