### PR TITLE
chore: Improve concurrency of compiling the code.

### DIFF
--- a/lib/formular/client/application.ex
+++ b/lib/formular/client/application.ex
@@ -5,7 +5,7 @@ defmodule Formular.Client.Application do
 
   def start(_type, _args) do
     children = [
-      Formular.Client.Compiler,
+      Formular.Client.Compiler.Supervisor,
       Formular.Client.Cache,
       Formular.Client.PubSub,
       {DynamicSupervisor, name: Formular.Client.Instances, strategy: :one_for_one}

--- a/lib/formular/client/compiler/supervisor.ex
+++ b/lib/formular/client/compiler/supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Formular.Client.Compiler.Supervisor do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts)
+  end
+
+  def init(_opts) do
+    children = [
+      {Registry, keys: :unique, name: Formular.Client.Compiler.Registry}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/test/formular/compiler_test.exs
+++ b/test/formular/compiler_test.exs
@@ -37,10 +37,10 @@ defmodule Formular.Client.CompilerTest do
       ref = make_ref()
 
       config = %{config | compiler: compiler}
-      Compiler.handle_new_code_revision({self(), ref}, "discount", "0.9", config, opts)
+      Compiler.handle_new_code_revision({parent, ref}, "discount", "0.9", config, opts)
 
-      assert_receive {^ref, :ok}
-      assert_receive {"0.9", "discount", ^opts}
+      assert_receive {^ref, :ok}, 1_000
+      assert_receive {"0.9", "discount", ^opts}, 1_000
     end
   end
 end


### PR DESCRIPTION
Performance improved for compiling the code.

1. Default timeout of compilation is increased from 5 seconds to 1 minute.
2. Different codes can now be compiled concurrently. Note pieces of code under the same name are still queued. 